### PR TITLE
Remount / with barrier=0 when fstype is ext4

### DIFF
--- a/arch-luks-suspend
+++ b/arch-luks-suspend
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e -u
 trap 'echo "Press ENTER to continue."; read dummy' ERR
@@ -9,20 +9,31 @@ trap 'echo "Press ENTER to continue."; read dummy' ERR
 INITRAMFS_DIR=/run/initramfs
 SYSTEM_SLEEP_PATH=/usr/lib/systemd/system-sleep
 BIND_PATHS="/sys /proc /dev /run"
+REMOUNT=0
+# Retrieve cryptdevice name from boot cmdline
+CRYPTNAME="$(sed -n 's/.*cryptdevice=[^: ]*:\([^: ]*\).*$/\1/p' /proc/cmdline)"
 
 # run_dir DIR ARGS...
 # Run all executable scripts in directory DIR with arguments ARGS
 run_dir() {
-    dir=$1
+    local dir=$1
     shift
     find "${dir}" -type f -executable -exec "{}" "$@" ";"
 }
 
 # Restore chroot
 umount_initramfs() {
+    local p
     for p in ${BIND_PATHS}; do
         ! mountpoint -q "${INITRAMFS_DIR}${p}" || umount "${INITRAMFS_DIR}${p}"
     done
+}
+
+ext4_cryptdevice_mount_options() {
+    local mt="$(grep "^/dev/mapper/${1} " /proc/mounts | cut -d ' ' -f 3,4)"
+    if [[ "${mt:0:5}" == "ext4 " ]]; then
+        echo "${mt:5}"
+    fi
 }
 
 ################################################################################
@@ -46,12 +57,26 @@ systemctl stop systemd-udevd-control.socket
 systemctl stop systemd-udevd-kernel.socket
 systemctl stop systemd-udevd.service
 
+# Journalled ext4 filesystems in kernel versions 3.11+ will block suspend
+# if mounted with `barrier=1`, which is the default. Temporarily remount with
+# `barrier=0` if this is true of the crypt fs.
+MOUNT_OPTS="$(ext4_cryptdevice_mount_options "$CRYPTNAME")"
+if [[ "$MOUNT_OPTS" ]] && ! [[ "$MOUNT_OPTS" == *nobarrier* || "$MOUNT_OPTS" == *barrier=0* ]]; then
+    REMOUNT=1
+    mount -o remount,"$MOUNT_OPTS",barrier=0 /
+fi
+
 # Synchronize filesystems before luksSuspend
 sync
 
 # Hand over execution to script inside initramfs
 cd "${INITRAMFS_DIR}"
-chroot . /suspend
+chroot . /suspend "$CRYPTNAME"
+
+# Restore original mount options if necessary
+if ((REMOUNT)); then
+    mount -o remount,"$MOUNT_OPTS",barrier=1 /
+fi
 
 # Restart udev
 systemctl start systemd-udevd-control.socket

--- a/initramfs-suspend
+++ b/initramfs-suspend
@@ -1,10 +1,9 @@
 #!/usr/bin/ash
 
+cryptname="${1}"
+
 # Start udev from initramfs
 /usr/lib/systemd/systemd-udevd --daemon --resolve-names=never
-
-# Retrieve cryptdevice name from boot cmdline
-cryptname=$(sed -n 's/.*cryptdevice=[^: ]*:\([^: ]*\).*$/\1/p' /proc/cmdline)
 
 # Suspend root device
 [ -z "${cryptname}" ] || cryptsetup luksSuspend "${cryptname}"


### PR DESCRIPTION
Numerous people¹ have reported that `echo mem > /sys/power/state` fails
to suspend their machines. This is likely due to the following ext4
commit², which was created to increase data integrity:

https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=06a407f13daf9e48f0ef7189c7e54082b53940c7

kernel/power/suspend.c:pm_suspend() calls sys_sync() during sleep
preparation, which in turn calls fs/ext4/super.c:ext4_sync_fs(). After
the above commit, if the `sbi->s_journal->j_flags & JBD2_BARRIER`
condition returns >0, a final flush + wait is called on the underlying
block device.

Since the block device is the one we just suspended with `luksSuspend`,
the call hangs indefinitely and the machine never enters sleep.

Mounting an ext4 fs with the `barrier=0` or `nobarrier` option avoids
this lockup.

The corresponding ext3 sync fn does not appear to be affected, but this
is untested.

¹ @seanlynch in issue #2, a user on the AUR project page, and a Red Hat
  user in the following bug report:

  https://bugzilla.redhat.com/show_bug.cgi?id=1013304#c0

PATCH NOTES:

I changed the #! to /bin/bash to take advantage of the `local` statement
and the `${VAR:i:n}` expansion; I am happy to revert these back to POSIX
equivalents if /bin/sh compat is important to you.

Thanks!
