### PR TITLE
Suspend all LUKS devices, not just the root device

### DIFF
--- a/arch-luks-suspend
+++ b/arch-luks-suspend
@@ -5,7 +5,7 @@
 
 INITRAMFS_DIR=/run/initramfs
 SYSTEM_SLEEP_PATH=/usr/lib/systemd/system-sleep
-BIND_PATHS="/sys /proc /dev /run"
+BIND_PATHS=(/sys /proc /dev /run)
 REMOUNT=0
 # Retrieve cryptdevice name from boot cmdline
 CRYPTNAME="$(sed -n 's/.*cryptdevice=[^: ]*:\([^: ]*\).*$/\1/p' /proc/cmdline)"
@@ -24,10 +24,16 @@ run_dir() {
     find "${dir}" -type f -executable -exec "{}" "$@" ";"
 }
 
-# Restore chroot
+mount_initramfs() {
+    local p
+    for p in "${BIND_PATHS[@]}"; do
+        mount -o bind "${p}" "${INITRAMFS_DIR}${p}"
+    done
+}
+
 umount_initramfs() {
     local p
-    for p in ${BIND_PATHS}; do
+    for p in "${BIND_PATHS[@]}"; do
         ! mountpoint -q "${INITRAMFS_DIR}${p}" || umount "${INITRAMFS_DIR}${p}"
     done
 }
@@ -39,6 +45,15 @@ ext4_cryptdevice_mount_options() {
     fi
 }
 
+# Stop udev service and prevent it to be autostarted.
+# Otherwise, luksResume will hang waiting for udev, which is itself waiting
+# for I/O on the root device.
+udev_service() {
+    systemctl "$1" systemd-udevd-control.socket
+    systemctl "$1" systemd-udevd-kernel.socket
+    systemctl "$1" systemd-udevd.service
+}
+
 ################################################################################
 ## Main script
 
@@ -46,19 +61,13 @@ ext4_cryptdevice_mount_options() {
 
 # Prepare chroot
 trap umount_initramfs EXIT
-for p in ${BIND_PATHS}; do
-    mount -o bind ${p} "${INITRAMFS_DIR}${p}"
-done
+mount_initramfs
 
 # Run pre-suspend scripts
 run_dir "${SYSTEM_SLEEP_PATH}" pre suspend
 
-# Stop udev service and prevent it to be autostarted.
-# Otherwise, luksResume will hang waiting for udev, which is itself waiting
-# for I/O on the root device.
-systemctl stop systemd-udevd-control.socket
-systemctl stop systemd-udevd-kernel.socket
-systemctl stop systemd-udevd.service
+# Stop services that may block suspend
+udev_service stop
 
 # Journalled ext4 filesystems in kernel versions 3.11+ will block suspend
 # if mounted with `barrier=1`, which is the default. Temporarily remount with
@@ -81,10 +90,8 @@ if ((REMOUNT)); then
     mount -o remount,"$MOUNT_OPTS",barrier=1 /
 fi
 
-# Restart udev
-systemctl start systemd-udevd-control.socket
-systemctl start systemd-udevd-kernel.socket
-systemctl start systemd-udevd.service
+# Restart stopped services
+udev_service start
 
 # Run post-suspend scripts
 run_dir "${SYSTEM_SLEEP_PATH}" post suspend

--- a/arch-luks-suspend
+++ b/arch-luks-suspend
@@ -54,6 +54,13 @@ udev_service() {
     systemctl "$1" systemd-udevd.service
 }
 
+# Prevent journald from attempting to write to the suspended device
+journald_service() {
+    systemctl "$1" systemd-journald-dev-log.socket
+    systemctl "$1" systemd-journald.socket
+    systemctl "$1" systemd-journald.service
+}
+
 ################################################################################
 ## Main script
 
@@ -68,6 +75,7 @@ run_dir "${SYSTEM_SLEEP_PATH}" pre suspend
 
 # Stop services that may block suspend
 udev_service stop
+journald_service stop
 
 # Journalled ext4 filesystems in kernel versions 3.11+ will block suspend
 # if mounted with `barrier=1`, which is the default. Temporarily remount with
@@ -91,6 +99,7 @@ if ((REMOUNT)); then
 fi
 
 # Restart stopped services
+journald_service start
 udev_service start
 
 # Run post-suspend scripts

--- a/arch-luks-suspend
+++ b/arch-luks-suspend
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-set -e -u
-trap 'echo "Press ENTER to continue."; read dummy' ERR
-
 ################################################################################
 ## Parameters and helper functions
 
@@ -12,6 +9,12 @@ BIND_PATHS="/sys /proc /dev /run"
 REMOUNT=0
 # Retrieve cryptdevice name from boot cmdline
 CRYPTNAME="$(sed -n 's/.*cryptdevice=[^: ]*:\([^: ]*\).*$/\1/p' /proc/cmdline)"
+
+panic() { while :; do echo o > /proc/sysrq-trigger; done }
+
+# Shutdown on script errors
+set -e -E -u
+trap panic ERR
 
 # run_dir DIR ARGS...
 # Run all executable scripts in directory DIR with arguments ARGS
@@ -39,7 +42,7 @@ ext4_cryptdevice_mount_options() {
 ################################################################################
 ## Main script
 
-[ -e "${INITRAMFS_DIR}/suspend" ] || exec /usr/lib/systemd/systemd-sleep suspend
+[[ -x "${INITRAMFS_DIR}/suspend" ]] || panic
 
 # Prepare chroot
 trap umount_initramfs EXIT

--- a/arch-luks-suspend
+++ b/arch-luks-suspend
@@ -6,9 +6,6 @@
 INITRAMFS_DIR=/run/initramfs
 SYSTEM_SLEEP_PATH=/usr/lib/systemd/system-sleep
 BIND_PATHS=(/sys /proc /dev /run)
-REMOUNT=0
-# Retrieve cryptdevice name from boot cmdline
-CRYPTNAME="$(sed -n 's/.*cryptdevice=[^: ]*:\([^: ]*\).*$/\1/p' /proc/cmdline)"
 
 panic() { while :; do echo o > /proc/sysrq-trigger; done }
 
@@ -38,11 +35,83 @@ umount_initramfs() {
     done
 }
 
-ext4_cryptdevice_mount_options() {
-    local mt="$(grep "^/dev/mapper/${1} " /proc/mounts | cut -d ' ' -f 3,4)"
-    if [[ "${mt:0:5}" == "ext4 " ]]; then
-        echo "${mt:5}"
+is_suspended() {
+    [[ "$(cat "$1/suspended")" -eq 1 ]]
+}
+
+needs_remount() {
+    local fs="$1" mtopts="$2"
+
+    if [[ "$fs" != ext4 ]]; then
+        echo 0
+    elif ! [[ "$mtopts" == *nobarrier* || "$mtopts" == *barrier=0* ]]; then
+        echo 1
+    else
+        echo 0
     fi
+}
+
+# Active crypt devices, each as a single word with 7 fields separated by 0x1C:
+# [/sys-dm-dir, dm-name, mountpoint, fstype, mount-options, keyfile, remount?]
+cryptdevices() {
+    local dm name mtpt fs mtopts __
+    local -A mounts keyfiles
+
+    while read -r key val; do
+        mounts["$key"]="$val"
+    done < /proc/mounts
+
+    # HACK: Extract name and pass fields from crypttab
+    while read -r key __ val __; do
+        keyfiles["$key"]="$val"
+    done < <(grep -v '^[ \t]*#\|^[ \t]*$' /etc/crypttab)
+
+    for dm in /sys/block/*/dm; do
+        if grep ^CRYPT "$dm/uuid" >/dev/null && ! is_suspended "$dm"; then
+            name="$(cat "$dm/name")"
+            read -r mtpt fs mtopts __ <<< "${mounts["/dev/mapper/$name"]:-}"
+            printf "%s\x1C%s\x1C%s\x1C%s\x1C%s\x1C%s\x1C%s\n" \
+                   "$dm" "$name" "$mtpt" "$fs" "$mtopts" "${keyfiles["$name"]:-}" \
+                   "$(needs_remount "$fs" "$mtopts")"
+        fi
+    done
+}
+
+# Journalled ext4 filesystems in kernel versions 3.11+ will block suspend if
+# mounted with `barrier=1`, which is the default. We can remount affected
+# devices with `barrier=0` to work around this.
+remount_blocking_devices() {
+    local remount_opts="$1" devices=("${@:2}")
+    local dev dm name mtpt fs mtopts keyfile remount
+    for dev in "${devices[@]}"; do
+        IFS=$'\x1C' read -r dm name mtpt fs mtopts keyfile remount <<< "$dev"
+        if ! is_suspended "$dm" && ((remount)); then
+            mount -o remount,"$mtopts","$remount_opts" "/dev/mapper/$name"
+        fi
+    done
+}
+
+# Write a simple tab-delimited table of [mountpoint, dm-name]
+write_cryptdevice_mounts() {
+    local file="$1" devices=("${@:2}")
+    > "$file"
+    local dev dm name mtpt fs mtopts keyfile remount
+    for dev in "${devices[@]}"; do
+        IFS=$'\x1C' read -r dm name mtpt fs mtopts keyfile remount <<< "$dev"
+        printf "%s\t%s\n" "$mtpt" "$name" >> "$file"
+    done
+}
+
+resume_devices_with_keyfiles() {
+    local devices=("$@")
+    local dev dm name mtpt fs mtopts keyfile remount
+    for dev in "${devices[@]}"; do
+        IFS=$'\x1C' read -r dm name mtpt fs mtopts keyfile remount <<< "$dev"
+        if is_suspended "$dm" && [[ -r "$keyfile" ]]; then
+            echo "Resuming $name"
+            cryptsetup --key-file "$keyfile" luksResume "$name"
+        fi
+    done
 }
 
 # Stop udev service and prevent it to be autostarted.
@@ -66,6 +135,9 @@ journald_service() {
 
 [[ -x "${INITRAMFS_DIR}/suspend" ]] || panic
 
+# NB. We will pass this variable unquoted to do word splitting
+CRYPTDEVICES="$(cryptdevices)"
+
 # Prepare chroot
 trap umount_initramfs EXIT
 mount_initramfs
@@ -77,26 +149,29 @@ run_dir "${SYSTEM_SLEEP_PATH}" pre suspend
 udev_service stop
 journald_service stop
 
-# Journalled ext4 filesystems in kernel versions 3.11+ will block suspend
-# if mounted with `barrier=1`, which is the default. Temporarily remount with
-# `barrier=0` if this is true of the crypt fs.
-MOUNT_OPTS="$(ext4_cryptdevice_mount_options "$CRYPTNAME")"
-if [[ "$MOUNT_OPTS" ]] && ! [[ "$MOUNT_OPTS" == *nobarrier* || "$MOUNT_OPTS" == *barrier=0* ]]; then
-    REMOUNT=1
-    mount -o remount,"$MOUNT_OPTS",barrier=0 /
-fi
-
 # Synchronize filesystems before luksSuspend
 sync
 
-# Hand over execution to script inside initramfs
-cd "${INITRAMFS_DIR}"
-chroot . /suspend "$CRYPTNAME"
+# Disable write barriers to avoid IO hangs
+remount_blocking_devices barrier=0 $CRYPTDEVICES
 
-# Restore original mount options if necessary
-if ((REMOUNT)); then
-    mount -o remount,"$MOUNT_OPTS",barrier=1 /
-fi
+# Hand over execution to script inside initramfs
+{
+    pushd .
+    cd "${INITRAMFS_DIR}"
+    umask 0077
+    write_cryptdevice_mounts run/cryptmounts $CRYPTDEVICES
+    chroot . /suspend run/cryptmounts
+    rm -f run/cryptmounts
+    popd
+} > /dev/null
+
+# The user has unlocked the root device, so now resume all other devices with
+# known keyfiles
+resume_devices_with_keyfiles $CRYPTDEVICES
+
+# Restore original mount options where necessary
+remount_blocking_devices barrier=1 $CRYPTDEVICES
 
 # Restart stopped services
 journald_service start

--- a/initramfs-suspend
+++ b/initramfs-suspend
@@ -2,18 +2,19 @@
 
 cryptname="${1}"
 
+panic() { while :; do echo o > /proc/sysrq-trigger; done }
+
 # Start udev from initramfs
 /usr/lib/systemd/systemd-udevd --daemon --resolve-names=never
 
-# Suspend root device
-[ -z "${cryptname}" ] || cryptsetup luksSuspend "${cryptname}"
+# Suspend root device, else shutdown
+cryptsetup luksSuspend "${cryptname}" || panic
 
 # Suspend the system
 echo mem > /sys/power/state
 
-# Resume root device
-[ -z "${cryptname}" ] ||
-    while ! cryptsetup luksResume "${cryptname}"; do sleep 2; done
+# Resume root device, else shutdown
+cryptsetup luksResume "${cryptname}" || panic
 
 # Stop udev from initramfs, as the real daemon from rootfs will be restarted
 udevadm control --exit

--- a/initramfs-suspend
+++ b/initramfs-suspend
@@ -1,20 +1,24 @@
 #!/usr/bin/ash
 
-cryptname="${1}"
+CRYPTMOUNTS_PATH="$1"
 
 panic() { while :; do echo o > /proc/sysrq-trigger; done }
 
 # Start udev from initramfs
 /usr/lib/systemd/systemd-udevd --daemon --resolve-names=never
 
-# Suspend root device, else shutdown
-cryptsetup luksSuspend "${cryptname}" || panic
+# Suspend crypt devices, else shutdown
+FAIL=0
+while IFS=$'\t' read -r mtpt name; do
+    cryptsetup luksSuspend "$name" || FAIL=1
+done < "$CRYPTMOUNTS_PATH"
+if test "$FAIL" -eq 1; then panic; fi
 
 # Suspend the system
 echo mem > /sys/power/state
 
 # Resume root device, else shutdown
-cryptsetup luksResume "${cryptname}" || panic
+cryptsetup luksResume "$(awk -F"\t" '/\/\t/{ print $2 }' "$CRYPTMOUNTS_PATH")" || panic
 
 # Stop udev from initramfs, as the real daemon from rootfs will be restarted
 udevadm control --exit

--- a/systemd-suspend.service
+++ b/systemd-suspend.service
@@ -1,3 +1,5 @@
+#  NOTE: This file masks /usr/lib/systemd/system/systemd-suspend.service
+#
 #  This file has been adapted from systemd.
 #
 #  systemd is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Patch 4abc1d094ee0dd950285125ae5d4c484ce6d69a0:

Multi-disk systems will likely have multiple LUKS devices open, so it is
important to also wipe the key for those devices.

However, entering a password to resume every device on wakeup is
tedious, so this patch attempts to resume all LUKS devices that have
a corresponding keyfile in /etc/crypttab once the user successfully
unlocks the device containing the root filesystem.

The parsing of /etc/crypttab is rudimentary and no special cryptsetup
options are handled, but this covers the conventional approach of
"unlock the root device, then unlock the other disks on the system with
keyfiles stored on the root device, specified in /etc/crypttab".

Note: Only 4abc1d094ee0dd950285125ae5d4c484ce6d69a0 is strictly
concerned with handling multiple LUKS devices. The other commits are
concerned with code organization and security (poweroff on failure).

I hope some of this looks appealing to you!

EDIT: I am happy to break this up into smaller pull requests if you 
like. Thanks!
