### PR TITLE
Add keyfile support

### DIFF
--- a/arch-luks-suspend
+++ b/arch-luks-suspend
@@ -12,6 +12,10 @@ BIND_PATHS="/sys /proc /dev /run"
 REMOUNT=0
 # Retrieve cryptdevice name from boot cmdline
 CRYPTNAME="$(sed -n 's/.*cryptdevice=[^: ]*:\([^: ]*\).*$/\1/p' /proc/cmdline)"
+# Retrieve cryptkey from boot cmdline
+CRYPTKEYDEV="$(sed -n 's/.*cryptkey=\([^: ]*\).*$/\1/p' /proc/cmdline)"
+CRYPTKEYFS="$(sed -n 's/.*cryptkey=[^: ]*:\([^: ]*\).*$/\1/p' /proc/cmdline)"
+CRYPTKEYFILE="$(sed -n 's/.*cryptkey=[^: ]*:[^: ]*:\([^: ]*\).*$/\1/p' /proc/cmdline)"
 
 # run_dir DIR ARGS...
 # Run all executable scripts in directory DIR with arguments ARGS
@@ -71,7 +75,7 @@ sync
 
 # Hand over execution to script inside initramfs
 cd "${INITRAMFS_DIR}"
-chroot . /suspend "$CRYPTNAME"
+chroot . /suspend "$CRYPTNAME" "$CRYPTKEYDEV" "$CRYPTKEYFS" "$CRYPTKEYFILE"
 
 # Restore original mount options if necessary
 if ((REMOUNT)); then

--- a/initramfs-suspend
+++ b/initramfs-suspend
@@ -15,12 +15,13 @@ cryptkeymountpoint="/rootkey"
 # Suspend the system
 echo mem > /sys/power/state
 
-# Wait for keydev
-while ! [ -e "${cryptkeydev}" ]; do sleep 0.5; done
 
-# Mount keyfile
 if [ -n "${cryptkeydev}" ] && [ -n "${cryptkeyfs}" ] && [ -n "${cryptkeyfile}" ]
 then
+    # Wait for keydev
+    while ! [ -e "${cryptkeydev}" ]; do sleep 0.5; done
+
+    # Mount keydev
     mkdir "${cryptkeymountpoint}"
     mount -t "${cryptkeyfs}" "${cryptkeydev}" "${cryptkeymountpoint}"
     lukskeyfilearg="--key-file ${cryptkeymountpoint}${cryptkeyfile}"

--- a/initramfs-suspend
+++ b/initramfs-suspend
@@ -15,15 +15,11 @@ cryptkeymountpoint="/rootkey"
 # Suspend the system
 echo mem > /sys/power/state
 
-
+# Mount keydev
 if [ -n "${cryptkeydev}" ] && [ -n "${cryptkeyfs}" ] && [ -n "${cryptkeyfile}" ]
 then
-    # Wait for keydev
-    while ! [ -e "${cryptkeydev}" ]; do sleep 0.5; done
-
-    # Mount keydev
     mkdir "${cryptkeymountpoint}"
-    mount -t "${cryptkeyfs}" "${cryptkeydev}" "${cryptkeymountpoint}"
+    while ! mount -t "${cryptkeyfs}" "${cryptkeydev}" "${cryptkeymountpoint}"; do sleep 2; done
     lukskeyfilearg="--key-file ${cryptkeymountpoint}${cryptkeyfile}"
 fi
 

--- a/initramfs-suspend
+++ b/initramfs-suspend
@@ -1,6 +1,10 @@
 #!/usr/bin/ash
 
 cryptname="${1}"
+cryptkeydev="${2}"
+cryptkeyfs="${3}"
+cryptkeyfile="${4}"
+cryptkeymountpoint="/rootkey"
 
 # Start udev from initramfs
 /usr/lib/systemd/systemd-udevd --daemon --resolve-names=never
@@ -11,9 +15,27 @@ cryptname="${1}"
 # Suspend the system
 echo mem > /sys/power/state
 
+# Wait for keydev
+while ! [ -e "${cryptkeydev}" ]; do sleep 0.5; done
+
+# Mount keyfile
+if [ -n "${cryptkeydev}" ] && [ -n "${cryptkeyfs}" ] && [ -n "${cryptkeyfile}" ]
+then
+    mkdir "${cryptkeymountpoint}"
+    mount -t "${cryptkeyfs}" "${cryptkeydev}" "${cryptkeymountpoint}"
+    lukskeyfilearg="--key-file ${cryptkeymountpoint}${cryptkeyfile}"
+fi
+
 # Resume root device
 [ -z "${cryptname}" ] ||
-    while ! cryptsetup luksResume "${cryptname}"; do sleep 2; done
+    while ! cryptsetup luksResume ${lukskeyfilearg} "${cryptname}"; do sleep 2; done
+
+# Clean up keyfile
+if [ -d "${cryptkeymountpoint}" ]
+then
+    umount "${cryptkeymountpoint}"
+    rmdir "${cryptkeymountpoint}"
+fi
 
 # Stop udev from initramfs, as the real daemon from rootfs will be restarted
 udevadm control --exit


### PR DESCRIPTION
Add support for luks keyfile (`--key-file` option to cryptsetup), by parsing the `cryptkey` option from the kernel commandline [1].
If the option is not set or could not be parsed correctly, this falls back to the old behaviour (i.e. prompt for passphrase)

[1]: https://wiki.archlinux.org/index.php/Dm-crypt/Device_encryption#Configuring_the_kernel_parameters